### PR TITLE
Add Apache 2.0 copyright headers to all Rust source files

### DIFF
--- a/fortitude/benches/manual_lookup_time_validation.rs
+++ b/fortitude/benches/manual_lookup_time_validation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Manual Lookup Time Reduction Validation
 //! This benchmark suite validates the core value proposition:
 //! >50% reduction in manual lookup time through proactive research

--- a/fortitude/benches/performance_validation.rs
+++ b/fortitude/benches/performance_validation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Fortitude Performance Validation Benchmarks
 //! This benchmark suite validates the core Fortitude performance targets:
 //! - Gap analysis <500ms for project scan up to 1000 files

--- a/fortitude/benches/quality_control_performance_benchmarks.rs
+++ b/fortitude/benches/quality_control_performance_benchmarks.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance benchmarks for quality control systems
 //! This benchmark suite validates that the quality control systems meet
 //! the performance requirements:

--- a/fortitude/benches/quality_metrics_performance.rs
+++ b/fortitude/benches/quality_metrics_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Performance benchmarks for the automated quality metrics collection system
 // Validates that performance requirements are met:
 // - Collection overhead: <5ms per research operation

--- a/fortitude/benches/quality_optimization_performance.rs
+++ b/fortitude/benches/quality_optimization_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Performance benchmarks: Quality-based provider selection optimization
 //! Validates that the optimization system meets performance requirements:
 //! - Provider selection latency: <100ms for real-time optimization

--- a/fortitude/benches/quality_scoring_benchmarks.rs
+++ b/fortitude/benches/quality_scoring_benchmarks.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance benchmarks for quality scoring algorithms
 //! Comprehensive benchmarks to validate that the quality scoring system
 //! meets performance requirements (<100ms evaluation time) and scales

--- a/fortitude/benches/workflow_efficiency_validation.rs
+++ b/fortitude/benches/workflow_efficiency_validation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Workflow Efficiency Validation Benchmarks
 //! Validates the impact of proactive research on developer workflow efficiency
 //!

--- a/fortitude/claude_code_provider_test.rs
+++ b/fortitude/claude_code_provider_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Ad-hoc test for Claude Code provider functionality
 // This demonstrates that the provider can generate research responses
 // and validates the quality of the results

--- a/fortitude/crates/fortitude-api-server/benches/api_benchmarks.rs
+++ b/fortitude/crates/fortitude-api-server/benches/api_benchmarks.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Server - Performance Benchmarks
 //!
 //! Comprehensive benchmark suite using criterion to validate API performance

--- a/fortitude/crates/fortitude-api-server/benches/cache_performance.rs
+++ b/fortitude/crates/fortitude-api-server/benches/cache_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Server - Cache Performance Benchmarks
 //!
 //! Specialized benchmarks to validate cache hit rate targets (>80%) and

--- a/fortitude/crates/fortitude-api-server/benches/concurrent_load_test.rs
+++ b/fortitude/crates/fortitude-api-server/benches/concurrent_load_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Server - Concurrent Load Testing
 //!
 //! Specialized load testing benchmarks to validate 100+ concurrent request

--- a/fortitude/crates/fortitude-api-server/examples/rust-client/src/lib.rs
+++ b/fortitude/crates/fortitude-api-server/examples/rust-client/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Rust Client Library
 //! 
 //! A comprehensive Rust client for the Fortitude API with support for

--- a/fortitude/crates/fortitude-api-server/examples/rust-client/src/performance_test.rs
+++ b/fortitude/crates/fortitude-api-server/examples/rust-client/src/performance_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Performance Testing
 //! 
 //! Comprehensive performance testing and validation for the Fortitude API,

--- a/fortitude/crates/fortitude-api-server/src/config.rs
+++ b/fortitude/crates/fortitude-api-server/src/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configuration management for Fortitude API server
 // Handles HTTP server configuration with authentication, performance, and security settings
 // Reuses patterns from MCP server with HTTP-specific extensions

--- a/fortitude/crates/fortitude-api-server/src/extractors.rs
+++ b/fortitude/crates/fortitude-api-server/src/extractors.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Custom Axum extractors that handle deserialization errors gracefully
 // Provides safe query parameter parsing that converts errors to proper 400 responses
 

--- a/fortitude/crates/fortitude-api-server/src/lib.rs
+++ b/fortitude/crates/fortitude-api-server/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Fortitude API Server library providing production-ready JSON REST API
 // Includes authentication, caching, research endpoints, and comprehensive testing
 

--- a/fortitude/crates/fortitude-api-server/src/main.rs
+++ b/fortitude/crates/fortitude-api-server/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: HTTP API server entry point for Fortitude research system
 // Provides production-ready JSON REST API with authentication, caching, and comprehensive endpoints
 

--- a/fortitude/crates/fortitude-api-server/src/middleware/auth.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/auth.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Authentication middleware for HTTP API server
 // Adapts JWT authentication from MCP server for HTTP Bearer tokens
 

--- a/fortitude/crates/fortitude-api-server/src/middleware/cors.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/cors.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: CORS middleware configuration for API server cross-origin requests
 
 use axum::http::Method;

--- a/fortitude/crates/fortitude-api-server/src/middleware/logging.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/logging.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Logging middleware for request/response tracing and monitoring
 
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};

--- a/fortitude/crates/fortitude-api-server/src/middleware/mod.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: HTTP middleware for Fortitude API server
 // Provides authentication, CORS, logging, rate limiting, and security middleware
 

--- a/fortitude/crates/fortitude-api-server/src/middleware/monitoring.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/monitoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Monitoring middleware for API server
 //! # API Server Monitoring Integration
 //!

--- a/fortitude/crates/fortitude-api-server/src/middleware/pattern_tracking.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/pattern_tracking.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Middleware for tracking API interaction patterns for learning system
 //! # Pattern Tracking Middleware
 //!

--- a/fortitude/crates/fortitude-api-server/src/middleware/rate_limit.rs
+++ b/fortitude/crates/fortitude-api-server/src/middleware/rate_limit.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Rate limiting middleware using tower-governor for API protection
 // NOTE: Placeholder implementation - will be completed in Task 2: Basic Route Implementation
 

--- a/fortitude/crates/fortitude-api-server/src/models/errors.rs
+++ b/fortitude/crates/fortitude-api-server/src/models/errors.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Error model definitions and HTTP error responses for the API
 
 use axum::{

--- a/fortitude/crates/fortitude-api-server/src/models/mod.rs
+++ b/fortitude/crates/fortitude-api-server/src/models/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: HTTP-specific models for Fortitude API server
 // Defines request/response schemas and error handling for REST API
 

--- a/fortitude/crates/fortitude-api-server/src/models/requests.rs
+++ b/fortitude/crates/fortitude-api-server/src/models/requests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Request model definitions for API endpoints
 
 use serde::{Deserialize, Serialize};

--- a/fortitude/crates/fortitude-api-server/src/models/responses.rs
+++ b/fortitude/crates/fortitude-api-server/src/models/responses.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Response model definitions for API endpoints
 
 use chrono::{DateTime, Utc};

--- a/fortitude/crates/fortitude-api-server/src/monitoring_types.rs
+++ b/fortitude/crates/fortitude-api-server/src/monitoring_types.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Mock monitoring types for API server monitoring endpoints
 // These types simulate the actual monitoring system for dashboard display
 

--- a/fortitude/crates/fortitude-api-server/src/routes/cache.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/cache.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Cache management endpoint handlers for API server
 // Provides HTTP endpoints for cache operations and analytics
 

--- a/fortitude/crates/fortitude-api-server/src/routes/classification.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/classification.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Classification endpoint handlers for API server
 // Provides HTTP endpoints for advanced classification system integration with full fortitude-core support
 

--- a/fortitude/crates/fortitude-api-server/src/routes/health.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/health.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Health check endpoints for API server monitoring and status verification
 
 use crate::middleware::auth::Claims;

--- a/fortitude/crates/fortitude-api-server/src/routes/learning.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/learning.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Learning system dashboard and metrics API endpoints
 //! Learning system monitoring endpoints for dashboard integration
 //!

--- a/fortitude/crates/fortitude-api-server/src/routes/mod.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: HTTP route handlers for Fortitude API server
 // Organizes endpoint handlers by domain (research, classification, cache, health, proactive, providers)
 

--- a/fortitude/crates/fortitude-api-server/src/routes/monitoring.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/monitoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Monitoring dashboard endpoints for system observability and performance tracking
 
 use crate::models::responses::{

--- a/fortitude/crates/fortitude-api-server/src/routes/proactive.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/proactive.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Proactive research endpoint handlers for API server
 // Provides HTTP endpoints for proactive research management with full ProactiveManager integration
 

--- a/fortitude/crates/fortitude-api-server/src/routes/providers.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/providers.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Provider management API endpoints for Sprint 009 Task 5
 // Provides REST API for multi-LLM provider management, health monitoring, and performance metrics
 

--- a/fortitude/crates/fortitude-api-server/src/routes/quality.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/quality.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Quality metrics API endpoints for monitoring and dashboard access
 //! This module provides HTTP endpoints for accessing quality control metrics,
 //! performance data, and system health information for the quality control

--- a/fortitude/crates/fortitude-api-server/src/routes/research.rs
+++ b/fortitude/crates/fortitude-api-server/src/routes/research.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research endpoint handlers for API server
 // Provides HTTP endpoints for research pipeline integration with full fortitude-core integration
 

--- a/fortitude/crates/fortitude-api-server/src/server.rs
+++ b/fortitude/crates/fortitude-api-server/src/server.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Main HTTP server implementation for Fortitude API server
 // Provides production-ready Axum-based server with middleware stack and graceful shutdown
 

--- a/fortitude/crates/fortitude-api-server/tests/anchor_learning_dashboard_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/anchor_learning_dashboard_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Anchor tests for learning dashboard API endpoints critical functionality
 //! Critical anchor tests for learning system monitoring dashboard endpoints.
 //!

--- a/fortitude/crates/fortitude-api-server/tests/anchor_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Anchor tests to verify API server maintains expected behavior across changes
 // These tests serve as a safety net to catch regressions during development
 

--- a/fortitude/crates/fortitude-api-server/tests/api_documentation_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/api_documentation_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: OpenAPI specification validation and documentation tests
 // Ensures the API documentation is accurate and accessible
 

--- a/fortitude/crates/fortitude-api-server/tests/integration_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/integration_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for API server endpoints and middleware
 // Tests actual HTTP server functionality with real requests
 

--- a/fortitude/crates/fortitude-api-server/tests/learning_dashboard_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/learning_dashboard_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for learning dashboard API endpoints
 //! Tests for learning metrics dashboard endpoints that integrate with the learning system
 

--- a/fortitude/crates/fortitude-api-server/tests/monitoring_dashboard_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/monitoring_dashboard_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive tests for monitoring dashboard endpoints following TDD approach
 
 use axum::{

--- a/fortitude/crates/fortitude-api-server/tests/performance_tests.rs
+++ b/fortitude/crates/fortitude-api-server/tests/performance_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Fortitude API Server - Performance Validation Tests
 //!
 //! Comprehensive performance validation tests to ensure Sprint 006 targets

--- a/fortitude/crates/fortitude-cli/src/config.rs
+++ b/fortitude/crates/fortitude-cli/src/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configuration management for the Fortitude CLI
 use serde::{Deserialize, Serialize};
 use std::env;

--- a/fortitude/crates/fortitude-cli/src/lib.rs
+++ b/fortitude/crates/fortitude-cli/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: CLI library for the Fortitude research system
 //! This library provides configuration management and utilities for the Fortitude CLI.
 

--- a/fortitude/crates/fortitude-cli/src/main.rs
+++ b/fortitude/crates/fortitude-cli/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: CLI application for the Fortitude research system
 #![allow(clippy::wildcard_in_or_patterns)]
 use clap::{Parser, Subcommand};

--- a/fortitude/crates/fortitude-cli/tests/anchor_tests.rs
+++ b/fortitude/crates/fortitude-cli/tests/anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Anchor integration tests for core Fortitude functionality.
 //!
 //! These tests verify critical functionality and should be maintained

--- a/fortitude/crates/fortitude-core/benches/embedding_performance.rs
+++ b/fortitude/crates/fortitude-core/benches/embedding_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use fortitude_core::vector::{VectorConfig, EmbeddingService, MockEmbeddingService};
 use std::time::Duration;

--- a/fortitude/crates/fortitude-core/benches/search_performance.rs
+++ b/fortitude/crates/fortitude-core/benches/search_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use fortitude_core::vector::{
     HybridSearchConfig, SearchOptions, SearchStrategy, SemanticSearchConfig, VectorConfig,

--- a/fortitude/crates/fortitude-core/benches/storage_performance.rs
+++ b/fortitude/crates/fortitude-core/benches/storage_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use fortitude_core::vector::{VectorConfig, VectorDocument, DocumentMetadata};
 use std::collections::HashMap;

--- a/fortitude/crates/fortitude-core/benches/vector_performance.rs
+++ b/fortitude/crates/fortitude-core/benches/vector_performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive vector operations performance benchmarks
 //! This benchmark suite measures the performance of core vector operations
 //! including client initialization, collection management, and health checks.

--- a/fortitude/crates/fortitude-core/examples/hybrid_search_demo.rs
+++ b/fortitude/crates/fortitude-core/examples/hybrid_search_demo.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Demonstration of hybrid search capabilities combining vector and keyword search
 //! This example showcases the hybrid search functionality that combines semantic vector
 //! search with traditional keyword search for improved relevance and precision.

--- a/fortitude/crates/fortitude-core/examples/performance_optimization_demo.rs
+++ b/fortitude/crates/fortitude-core/examples/performance_optimization_demo.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Demonstration of the comprehensive performance optimization system
 //! This example shows how the performance optimizations work together to achieve
 //! the <200ms target response time for vector operations.

--- a/fortitude/crates/fortitude-core/examples/semantic_search_demo.rs
+++ b/fortitude/crates/fortitude-core/examples/semantic_search_demo.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Demonstration of semantic search functionality
 //! This example shows how to use the SemanticSearchService for vector-based
 //! content discovery and similarity search operations.

--- a/fortitude/crates/fortitude-core/src/api/claude.rs
+++ b/fortitude/crates/fortitude-core/src/api/claude.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Claude API client implementation with rate limiting and retry logic
 use async_trait::async_trait;
 use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};

--- a/fortitude/crates/fortitude-core/src/api/client.rs
+++ b/fortitude/crates/fortitude-core/src/api/client.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Generic API client traits and configurations
 use crate::api::error::ApiResult;
 use async_trait::async_trait;

--- a/fortitude/crates/fortitude-core/src/api/error.rs
+++ b/fortitude/crates/fortitude-core/src/api/error.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Error types for API client operations
 use reqwest::StatusCode;
 use std::time::Duration;

--- a/fortitude/crates/fortitude-core/src/api/mod.rs
+++ b/fortitude/crates/fortitude-core/src/api/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: API module for external service integrations
 //! This module provides API client implementations for external services
 //! including Claude API integration for research generation.

--- a/fortitude/crates/fortitude-core/src/classification/advanced_classifier.rs
+++ b/fortitude/crates/fortitude-core/src/classification/advanced_classifier.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Advanced multi-dimensional classifier with rule composition and context detection
 use crate::classification::{
     basic_classifier::BasicClassifier,

--- a/fortitude/crates/fortitude-core/src/classification/basic_classifier.rs
+++ b/fortitude/crates/fortitude-core/src/classification/basic_classifier.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Basic keyword-based classification engine for research type detection
 use fortitude_types::{
     AudienceContext, ClassificationCandidate, ClassificationConfig, ClassificationError,

--- a/fortitude/crates/fortitude-core/src/classification/context_detector.rs
+++ b/fortitude/crates/fortitude-core/src/classification/context_detector.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Main context detection engine for audience level, technical domain, and urgency classification
 use crate::classification::rules::{AudienceRules, DomainRules, UrgencyRules};
 use fortitude_types::{

--- a/fortitude/crates/fortitude-core/src/classification/mod.rs
+++ b/fortitude/crates/fortitude-core/src/classification/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Classification system modules for multi-dimensional research classification
 
 // Basic classification engine

--- a/fortitude/crates/fortitude-core/src/classification/rules/audience_rules.rs
+++ b/fortitude/crates/fortitude-core/src/classification/rules/audience_rules.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Audience level detection rules for beginner, intermediate, and advanced classification
 use fortitude_types::{classification_result::AudienceLevel, ClassificationError};
 use regex::Regex;

--- a/fortitude/crates/fortitude-core/src/classification/rules/domain_rules.rs
+++ b/fortitude/crates/fortitude-core/src/classification/rules/domain_rules.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Technical domain detection rules for Rust, Web, DevOps, AI, Database, Systems, Security, and General classification
 use fortitude_types::{classification_result::TechnicalDomain, ClassificationError};
 use regex::Regex;

--- a/fortitude/crates/fortitude-core/src/classification/rules/mod.rs
+++ b/fortitude/crates/fortitude-core/src/classification/rules/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Context detection rules modules for multi-dimensional classification
 
 pub mod audience_rules;

--- a/fortitude/crates/fortitude-core/src/classification/rules/urgency_rules.rs
+++ b/fortitude/crates/fortitude-core/src/classification/rules/urgency_rules.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Urgency level detection rules for immediate, planned, and exploratory classification
 use fortitude_types::{classification_result::UrgencyLevel, ClassificationError};
 use regex::Regex;

--- a/fortitude/crates/fortitude-core/src/classification/scoring.rs
+++ b/fortitude/crates/fortitude-core/src/classification/scoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Confidence scoring system for rule composition and multi-dimensional classification
 use fortitude_types::{
     classification_result::{

--- a/fortitude/crates/fortitude-core/src/claude_code_integration_example.rs
+++ b/fortitude/crates/fortitude-core/src/claude_code_integration_example.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Example showing how to integrate ClaudeCodeProvider with Fortitude research engine
 // This demonstrates the configuration and usage pattern for Claude Code as a research fallback
 

--- a/fortitude/crates/fortitude-core/src/claude_code_provider.rs
+++ b/fortitude/crates/fortitude-core/src/claude_code_provider.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Claude Code integration provider for Fortitude research engine
 // Provides research capabilities by delegating to Claude Code with WebSearch tool usage
 // Acts as a fallback provider when external API keys are not available

--- a/fortitude/crates/fortitude-core/src/claude_code_research_engine.rs
+++ b/fortitude/crates/fortitude-core/src/claude_code_research_engine.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Claude Code Research Engine - implements ResearchEngine trait to call Claude Code as fallback
 // This engine provides research capabilities by delegating to Claude Code with WebSearch tool usage
 // Acts as the fallback provider when external API keys are not available

--- a/fortitude/crates/fortitude-core/src/enhanced_pipeline_example.rs
+++ b/fortitude/crates/fortitude-core/src/enhanced_pipeline_example.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Example demonstrating the enhanced research pipeline with vector search integration
 //! This module provides a comprehensive example of how to use the enhanced research
 //! pipeline with vector search context discovery, automatic indexing, and quality feedback.

--- a/fortitude/crates/fortitude-core/src/integration_tests.rs
+++ b/fortitude/crates/fortitude-core/src/integration_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for enhanced research workflows with vector search
 //! This module contains comprehensive integration tests for the enhanced research
 //! pipeline that includes vector search context discovery, automatic indexing,

--- a/fortitude/crates/fortitude-core/src/lib.rs
+++ b/fortitude/crates/fortitude-core/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Core business logic for the Fortitude research system
 //! This crate contains the core business logic for the Fortitude research
 //! system, including classification engines, storage systems, and pipeline

--- a/fortitude/crates/fortitude-core/src/multi_provider_research_engine.rs
+++ b/fortitude/crates/fortitude-core/src/multi_provider_research_engine.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Multi-provider research engine with intelligent provider selection and failover
 //! This module provides a research engine that leverages multiple LLM providers through the
 //! provider abstraction layer. It supports intelligent provider selection, automatic failover,

--- a/fortitude/crates/fortitude-core/src/pipeline.rs
+++ b/fortitude/crates/fortitude-core/src/pipeline.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research pipeline orchestrating classification and storage
 use crate::classification::{
     advanced_classifier::{AdvancedClassificationConfig, AdvancedClassifier},

--- a/fortitude/crates/fortitude-core/src/prompts/mod.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Prompt template system for type-specific research generation
 //! This module provides a template system for generating research prompts
 //! based on research type, with support for progressive disclosure and

--- a/fortitude/crates/fortitude-core/src/prompts/parameters.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/parameters.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Parameter system for prompt templates with type validation
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/fortitude/crates/fortitude-core/src/prompts/registry.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/registry.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Template registry for managing research templates by type
 use crate::prompts::parameters::ComplexityLevel;
 use crate::prompts::templates::{ResearchTemplate, TemplateError};

--- a/fortitude/crates/fortitude-core/src/prompts/substitution.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/substitution.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Template substitution engine for parameter replacement
 use crate::prompts::parameters::{ParameterError, ParameterValue};
 use regex::Regex;

--- a/fortitude/crates/fortitude-core/src/prompts/templates.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/templates.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Template system for research prompt generation
 use crate::prompts::parameters::{
     ComplexityLevel, ParameterDefinition, ParameterError, ParameterValidator, ParameterValue,

--- a/fortitude/crates/fortitude-core/src/prompts/validation.rs
+++ b/fortitude/crates/fortitude-core/src/prompts/validation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Template validation system for progressive disclosure and quality assurance
 use fortitude_types::research::{ResearchResult, ResearchType};
 use serde::{Deserialize, Serialize};

--- a/fortitude/crates/fortitude-core/src/research_engine.rs
+++ b/fortitude/crates/fortitude-core/src/research_engine.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research engine that generates research results using Claude API
 use async_trait::async_trait;
 use chrono::Utc;

--- a/fortitude/crates/fortitude-core/src/research_feedback.rs
+++ b/fortitude/crates/fortitude-core/src/research_feedback.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research quality feedback system for improving vector search relevance
 //! This module provides a feedback system for research quality assessment and
 //! vector search relevance improvement based on research outcomes.

--- a/fortitude/crates/fortitude-core/src/storage.rs
+++ b/fortitude/crates/fortitude-core/src/storage.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: File-based storage system with reference library integration
 use crate::classification::context_detector::ContextDetectionResult;
 use fortitude_types::{

--- a/fortitude/crates/fortitude-core/src/vector/cache.rs
+++ b/fortitude/crates/fortitude-core/src/vector/cache.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Advanced multi-level caching system for vector operations
 //! This module provides comprehensive caching strategies for embeddings, search results,
 //! and vector operations to achieve <200ms response times and optimize throughput.

--- a/fortitude/crates/fortitude-core/src/vector/client.rs
+++ b/fortitude/crates/fortitude-core/src/vector/client.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Qdrant client implementation with connection management and health checks
 use crate::api::{ApiClient, HealthStatus, RequestCost};
 use crate::vector::{VectorConfig, VectorError, VectorResult};

--- a/fortitude/crates/fortitude-core/src/vector/config.rs
+++ b/fortitude/crates/fortitude-core/src/vector/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configuration for vector database operations
 use crate::vector::embeddings::EmbeddingConfig;
 use crate::vector::error::{VectorError, VectorResult};

--- a/fortitude/crates/fortitude-core/src/vector/connection_pool.rs
+++ b/fortitude/crates/fortitude-core/src/vector/connection_pool.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Database connection pooling for optimized vector operations
 //! This module provides advanced connection pooling and database optimization
 //! for Qdrant operations to achieve <200ms response times.

--- a/fortitude/crates/fortitude-core/src/vector/embedding_tests.rs
+++ b/fortitude/crates/fortitude-core/src/vector/embedding_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive unit tests for embedding functionality
 #[cfg(test)]
 mod embedding_tests {

--- a/fortitude/crates/fortitude-core/src/vector/embeddings.rs
+++ b/fortitude/crates/fortitude-core/src/vector/embeddings.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Embedding generation service for converting text to vectors
 //! This module provides text-to-vector conversion capabilities using local
 //! embedding models with caching, batch processing, and error handling.

--- a/fortitude/crates/fortitude-core/src/vector/error.rs
+++ b/fortitude/crates/fortitude-core/src/vector/error.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Error types for vector database operations
 use std::time::Duration;
 use thiserror::Error;

--- a/fortitude/crates/fortitude-core/src/vector/hybrid.rs
+++ b/fortitude/crates/fortitude-core/src/vector/hybrid.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Hybrid search service combining vector similarity and keyword matching
 //! This module provides comprehensive hybrid search capabilities that combine semantic vector
 //! search with traditional keyword search for improved relevance and precision in research

--- a/fortitude/crates/fortitude-core/src/vector/migration.rs
+++ b/fortitude/crates/fortitude-core/src/vector/migration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Data migration system for migrating existing research content to vector storage
 //! This module provides comprehensive data migration capabilities for moving existing
 //! research content from file-based storage to vector database storage. It includes

--- a/fortitude/crates/fortitude-core/src/vector/mod.rs
+++ b/fortitude/crates/fortitude-core/src/vector/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Vector database module for semantic search capabilities
 //! This module provides vector database integration using Qdrant for semantic
 //! search capabilities, including client management, configuration, and error handling.

--- a/fortitude/crates/fortitude-core/src/vector/optimized_config.rs
+++ b/fortitude/crates/fortitude-core/src/vector/optimized_config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive performance-optimized configuration for vector operations
 //! This module provides a unified configuration system that optimizes all vector operations
 //! for <200ms response times with intelligent defaults and tuning parameters.

--- a/fortitude/crates/fortitude-core/src/vector/optimized_embeddings.rs
+++ b/fortitude/crates/fortitude-core/src/vector/optimized_embeddings.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Optimized embedding generation service with advanced caching and batching
 //! This module provides high-performance embedding generation optimized for <200ms response times
 //! with intelligent caching, batching, and model optimization strategies.

--- a/fortitude/crates/fortitude-core/src/vector/performance.rs
+++ b/fortitude/crates/fortitude-core/src/vector/performance.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance optimization and monitoring for vector operations
 //! This module provides comprehensive performance optimizations and monitoring
 //! to achieve <200ms response times for vector search operations.

--- a/fortitude/crates/fortitude-core/src/vector/regression_detection.rs
+++ b/fortitude/crates/fortitude-core/src/vector/regression_detection.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance regression detection system for vector operations
 //! This module provides automated detection of performance regressions and quality degradation
 //! in vector operations with alerting and auto-recovery capabilities.

--- a/fortitude/crates/fortitude-core/src/vector/search.rs
+++ b/fortitude/crates/fortitude-core/src/vector/search.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Semantic search service for research content discovery and vector similarity operations
 //! This module provides comprehensive semantic search capabilities for the Fortitude vector
 //! database system. It includes query processing, result ranking, filtering, and various

--- a/fortitude/crates/fortitude-core/src/vector/storage.rs
+++ b/fortitude/crates/fortitude-core/src/vector/storage.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Vector storage abstraction combining Qdrant client and embedding service
 //! This module provides a high-level vector storage interface that combines
 //! the Qdrant client for vector database operations and the embedding service

--- a/fortitude/crates/fortitude-core/src/vector/storage_tests.rs
+++ b/fortitude/crates/fortitude-core/src/vector/storage_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for vector storage operations
 
 use super::storage::*;

--- a/fortitude/crates/fortitude-core/src/vector/tests.rs
+++ b/fortitude/crates/fortitude-core/src/vector/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Unit tests for vector database functionality
 #[cfg(test)]
 mod vector_tests {

--- a/fortitude/crates/fortitude-core/src/vector/utils.rs
+++ b/fortitude/crates/fortitude-core/src/vector/utils.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Utility functions for vector database configuration conversion
 use crate::vector::{
     ConnectionPoolConfig, DistanceMetric, EmbeddingConfig, HealthCheckConfig, VectorConfig,

--- a/fortitude/crates/fortitude-core/tests/cache_key_anchor_tests.rs
+++ b/fortitude/crates/fortitude-core/tests/cache_key_anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Anchor tests for cache key generation stability
 //!
 //! ANCHOR: Critical cache key generation tests that protect against regressions

--- a/fortitude/crates/fortitude-core/tests/cache_key_stability_comprehensive.rs
+++ b/fortitude/crates/fortitude-core/tests/cache_key_stability_comprehensive.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Comprehensive cache key stability tests
 //!
 //! ANCHOR: Critical cache key generation tests that protect against regressions

--- a/fortitude/crates/fortitude-core/tests/cache_validation_simple.rs
+++ b/fortitude/crates/fortitude-core/tests/cache_validation_simple.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Simplified cache validation tests targeting the identified issues
 //!
 //! ANCHOR: Critical cache functionality tests that protect against regressions

--- a/fortitude/crates/fortitude-core/tests/cli_integration.rs
+++ b/fortitude/crates/fortitude-core/tests/cli_integration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Integration tests for CLI commands with vector services.
 //! These tests verify CLI functionality works correctly with the public API.
 

--- a/fortitude/crates/fortitude-core/tests/embedding_integration_test.rs
+++ b/fortitude/crates/fortitude-core/tests/embedding_integration_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration test for embedding generation functionality
 //! This test demonstrates the complete embedding generation pipeline
 //! from text input to vector output, including caching and batch processing.

--- a/fortitude/crates/fortitude-core/tests/enhanced_retrieval_tests.rs
+++ b/fortitude/crates/fortitude-core/tests/enhanced_retrieval_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Enhanced cache retrieval logic tests
 //!
 //! This test suite validates the enhanced cache retrieval and fallback mechanisms,

--- a/fortitude/crates/fortitude-core/tests/prompts_anchor_tests.rs
+++ b/fortitude/crates/fortitude-core/tests/prompts_anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Anchor tests for prompt template system critical functionality
 //! These tests verify critical functionality and should be maintained
 //! as the system evolves. Do not delete these tests.

--- a/fortitude/crates/fortitude-core/tests/prompts_integration.rs
+++ b/fortitude/crates/fortitude-core/tests/prompts_integration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for the prompt template system
 //! These tests verify the prompt template system works end-to-end
 //! without mocking internal components.

--- a/fortitude/crates/fortitude-core/tests/vector_anchor_tests.rs
+++ b/fortitude/crates/fortitude-core/tests/vector_anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! ABOUTME: Anchor tests for vector database critical functionality
 //! These tests verify critical functionality and should be maintained
 //! as the system evolves. Do not delete these tests.

--- a/fortitude/crates/fortitude-mcp-server/src/auth.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/auth.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: JWT authentication and authorization system for Fortitude MCP server
 // Provides production-ready security with token generation, validation, and permission-based access control
 // Includes rate limiting, input validation, and comprehensive security middleware

--- a/fortitude/crates/fortitude-mcp-server/src/config.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configuration management for Fortitude MCP server
 // Handles server configuration loading from files and environment variables
 // Supports validation and default values for production deployment

--- a/fortitude/crates/fortitude-mcp-server/src/lib.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP server library for Fortitude AI research assistant integration
 // Provides Model Context Protocol server implementation for seamless Claude Code integration
 // Exposes research tools and resources via MCP protocol for external AI model access

--- a/fortitude/crates/fortitude-mcp-server/src/main.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Main entry point for Fortitude MCP server
 // Provides command-line interface for starting the MCP server
 // Handles configuration loading and graceful shutdown

--- a/fortitude/crates/fortitude-mcp-server/src/monitoring.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/monitoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP server monitoring integration
 //! # MCP Server Monitoring Integration
 //!

--- a/fortitude/crates/fortitude-mcp-server/src/pattern_tracking.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/pattern_tracking.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Pattern tracking for MCP server tool calls
 //! # MCP Pattern Tracking
 //!

--- a/fortitude/crates/fortitude-mcp-server/src/proactive_tools.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/proactive_tools.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP tools implementation for proactive research functionality
 // Provides MCP tool wrappers around ProactiveManager functionality
 // Implements proactive_start, proactive_stop, proactive_status, proactive_configure,

--- a/fortitude/crates/fortitude-mcp-server/src/quality_tools.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/quality_tools.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP quality control tools for accessing quality metrics and management
 //! This module provides MCP tools for accessing quality control functionality
 //! implemented in Sprint 009, including metrics access, provider performance,

--- a/fortitude/crates/fortitude-mcp-server/src/resources.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/resources.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP resource providers for Fortitude reference library and system resources
 // Exposes reference library files, cache statistics, and configuration state via MCP protocol
 // Implements proper URI conventions and security for read-only access to docs/ directory

--- a/fortitude/crates/fortitude-mcp-server/src/server.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/server.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Production-ready MCP server implementation for Fortitude
 // Provides secure, performant Model Context Protocol server
 // Follows production patterns with authentication, error handling, and observability

--- a/fortitude/crates/fortitude-mcp-server/src/tools.rs
+++ b/fortitude/crates/fortitude-mcp-server/src/tools.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: MCP tool implementations that expose fortitude research functionality
 // Provides thin wrappers around existing ResearchPipeline functionality
 // Implements research_query, classify_query, and detect_context tools

--- a/fortitude/crates/fortitude-mcp-server/tests/anchor_tests.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/anchor_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Anchor tests for Fortitude MCP server critical functionality
 // These tests protect core system functionality from regression and must be maintained
 // Created following decision matrix from tests/README.md with ANCHOR: docstring comments

--- a/fortitude/crates/fortitude-mcp-server/tests/auth_integration.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/auth_integration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration tests for JWT authentication and authorization system
 // Tests end-to-end authentication flows, permission checking, and rate limiting
 // ANCHOR: Verifies authentication security works end-to-end with proper token validation and permission enforcement

--- a/fortitude/crates/fortitude-mcp-server/tests/common/mod.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/common/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Common test utilities for fortitude MCP server tests
 // Provides shared mocks, fixtures, and test helpers for comprehensive testing
 // Used by integration tests, performance tests, and anchor tests

--- a/fortitude/crates/fortitude-mcp-server/tests/error_handling_tests.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/error_handling_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive error handling and edge case tests for Fortitude MCP server
 // Tests error conditions, edge cases, and system resilience
 // Validates proper error handling throughout the system

--- a/fortitude/crates/fortitude-mcp-server/tests/integration_comprehensive.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/integration_comprehensive.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive integration tests for Fortitude MCP server
 // Tests end-to-end workflows, Claude Code integration patterns, and full system behavior
 // Covers authentication, research pipeline, resource access, and error handling

--- a/fortitude/crates/fortitude-mcp-server/tests/performance_tests.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/performance_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance tests for Fortitude MCP server
 // Tests 100+ concurrent requests capability, sub-100ms latency targets, and throughput under load
 // Validates performance requirements from sprint plan

--- a/fortitude/crates/fortitude-mcp-server/tests/proactive_tools_tests.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/proactive_tools_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Tests for proactive research MCP tools
 // Tests the ProactiveTools integration with MCP protocol
 // Following TDD approach with comprehensive test coverage

--- a/fortitude/crates/fortitude-mcp-server/tests/security_tests.rs
+++ b/fortitude/crates/fortitude-mcp-server/tests/security_tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Security-focused tests for Fortitude MCP server
 // Tests authentication, authorization, input validation, and security boundaries
 // Validates protection against common security threats

--- a/fortitude/crates/fortitude-test-utils/src/classification_fixtures.rs
+++ b/fortitude/crates/fortitude-test-utils/src/classification_fixtures.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Test fixtures for multi-dimensional classification testing
 use fortitude_types::{
     classification::{ClassificationCandidate, ClassificationConfig},

--- a/fortitude/crates/fortitude-test-utils/src/fixtures.rs
+++ b/fortitude/crates/fortitude-test-utils/src/fixtures.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Test fixtures for the Fortitude research system
 use chrono::Utc;
 use fortitude_types::*;

--- a/fortitude/crates/fortitude-test-utils/src/helpers.rs
+++ b/fortitude/crates/fortitude-test-utils/src/helpers.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Test helpers for the Fortitude research system
 use fortitude_types::*;
 use std::collections::HashMap;

--- a/fortitude/crates/fortitude-test-utils/src/lib.rs
+++ b/fortitude/crates/fortitude-test-utils/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Shared testing utilities for the Fortitude research system
 //! This crate contains shared testing utilities, fixtures, and helpers
 //! used across the Fortitude test suite.

--- a/fortitude/crates/fortitude-types/src/classification.rs
+++ b/fortitude/crates/fortitude-types/src/classification.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Classification types for the Fortitude research system
 use crate::research::ResearchType;
 use serde::{Deserialize, Serialize};

--- a/fortitude/crates/fortitude-types/src/classification_result.rs
+++ b/fortitude/crates/fortitude-types/src/classification_result.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Enhanced classification result types for multi-dimensional classification
 use crate::{classification::ClassificationCandidate, research::ResearchType};
 use serde::{Deserialize, Serialize};

--- a/fortitude/crates/fortitude-types/src/error.rs
+++ b/fortitude/crates/fortitude-types/src/error.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Error types for the Fortitude research system
 use std::path::PathBuf;
 use thiserror::Error;

--- a/fortitude/crates/fortitude-types/src/lib.rs
+++ b/fortitude/crates/fortitude-types/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Core types and errors for the Fortitude research system
 //! This crate contains the shared types and error definitions used across
 //! the Fortitude research pipeline. It defines the core domain types for

--- a/fortitude/crates/fortitude-types/src/pattern_recognition.rs
+++ b/fortitude/crates/fortitude-types/src/pattern_recognition.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Pattern recognition types for API and CLI interaction tracking
 //! # Pattern Recognition Types
 //!

--- a/fortitude/crates/fortitude-types/src/research.rs
+++ b/fortitude/crates/fortitude-types/src/research.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research domain types for the Fortitude research system
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/fortitude/crates/fortitude-types/src/storage.rs
+++ b/fortitude/crates/fortitude-types/src/storage.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Storage types for the Fortitude research system
 use crate::research::{ResearchResult, ResearchType};
 use chrono::{DateTime, Utc};

--- a/fortitude/demo_claude_code_provider.rs
+++ b/fortitude/demo_claude_code_provider.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Simple demonstration of Claude Code provider functionality
 // This shows the core concept without external dependencies
 

--- a/fortitude/simple_claude_code_test.rs
+++ b/fortitude/simple_claude_code_test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Simple test to demonstrate Claude Code provider functionality
 // This bypasses the complex trait implementation for demonstration
 

--- a/fortitude/src/knowledge.rs
+++ b/fortitude/src/knowledge.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::path::PathBuf;
 use thiserror::Error;
 

--- a/fortitude/src/learning/adaptation.rs
+++ b/fortitude/src/learning/adaptation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: System adaptation algorithms based on learning feedback and patterns
 //! # Adaptation Module
 //!

--- a/fortitude/src/learning/config.rs
+++ b/fortitude/src/learning/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configuration management for the learning system with environment support
 //! # Learning System Configuration
 //!

--- a/fortitude/src/learning/mod.rs
+++ b/fortitude/src/learning/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Learning system interfaces and core data models for real-time learning
 //! # Learning System Module
 //!

--- a/fortitude/src/learning/monitoring.rs
+++ b/fortitude/src/learning/monitoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Monitoring and health check implementation for the learning system
 //! # Learning System Monitoring
 //!

--- a/fortitude/src/learning/optimization.rs
+++ b/fortitude/src/learning/optimization.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance optimization algorithms based on learning insights
 //! # Optimization Module
 //!

--- a/fortitude/src/learning/pattern_recognition.rs
+++ b/fortitude/src/learning/pattern_recognition.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Usage pattern analysis and recognition for learning system
 //! # Pattern Recognition Module
 //!

--- a/fortitude/src/learning/storage.rs
+++ b/fortitude/src/learning/storage.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Learning data persistence with vector database integration
 //! Learning Data Storage Layer
 //!

--- a/fortitude/src/learning/template_integration.rs
+++ b/fortitude/src/learning/template_integration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integration layer between learning system adaptation algorithms and template/research systems
 //! # Template Integration Module
 //!

--- a/fortitude/src/lib.rs
+++ b/fortitude/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod knowledge;
 pub mod learning;
 pub mod monitoring;

--- a/fortitude/src/main.rs
+++ b/fortitude/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::{Parser, Subcommand};
 use fortitude::proactive::{ProactiveManager, ProactiveManagerConfig, ProactiveManagerError};
 use fortitude::providers::{HealthStatus, Provider};

--- a/fortitude/src/monitoring/alerts.rs
+++ b/fortitude/src/monitoring/alerts.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Alert management system for critical performance issues
 //! # Alert Management Module
 //!

--- a/fortitude/src/monitoring/config.rs
+++ b/fortitude/src/monitoring/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance monitoring configuration system
 //! # Monitoring Configuration
 //!

--- a/fortitude/src/monitoring/health.rs
+++ b/fortitude/src/monitoring/health.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Health check system for monitoring component status
 //! # Health Check Module
 //!

--- a/fortitude/src/monitoring/metrics.rs
+++ b/fortitude/src/monitoring/metrics.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance metrics collection for comprehensive system monitoring
 //! # Metrics Collection Module
 //!

--- a/fortitude/src/monitoring/mod.rs
+++ b/fortitude/src/monitoring/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Performance monitoring and observability system for Fortitude
 //! # Monitoring Module
 //!

--- a/fortitude/src/monitoring/tracing.rs
+++ b/fortitude/src/monitoring/tracing.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Distributed tracing system for request flow tracking
 //! # Distributed Tracing Module
 //!

--- a/fortitude/src/pipeline.rs
+++ b/fortitude/src/pipeline.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/fortitude/src/proactive/background_scheduler.rs
+++ b/fortitude/src/proactive/background_scheduler.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Background task scheduler with persistent queue and priority ordering for proactive research
 //! This module provides a persistent task queue system with priority ordering for managing
 //! background research tasks. Features include:

--- a/fortitude/src/proactive/comprehensive_config.rs
+++ b/fortitude/src/proactive/comprehensive_config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive proactive configuration management system
 //! # Comprehensive Proactive Configuration Management
 //!

--- a/fortitude/src/proactive/config.rs
+++ b/fortitude/src/proactive/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configurable gap detection rules and thresholds for proactive research mode
 //! This module provides comprehensive configuration for gap detection rules, semantic analysis
 //! thresholds, and system behavior tuning. It allows users to customize gap detection behavior,

--- a/fortitude/src/proactive/configurable_analyzer.rs
+++ b/fortitude/src/proactive/configurable_analyzer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Configurable gap analyzer that integrates configuration system with existing detection
 //! This module provides a configurable wrapper around the existing gap analyzer that uses
 //! the comprehensive configuration system to control detection behavior, rules, and thresholds.

--- a/fortitude/src/proactive/context_aware_scorer.rs
+++ b/fortitude/src/proactive/context_aware_scorer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Context-aware priority scoring using classification system for intelligent research prioritization
 //! This module provides context-aware priority scoring that leverages the existing classification system
 //! to provide intelligent priority adjustments based on research context, domain, and classification metadata.

--- a/fortitude/src/proactive/error_handler.rs
+++ b/fortitude/src/proactive/error_handler.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Comprehensive error handling and retry mechanisms for proactive research components
 //! This module provides centralized error handling, retry mechanisms, and circuit breaker patterns
 //! for the proactive research system. Features include:

--- a/fortitude/src/proactive/file_monitor.rs
+++ b/fortitude/src/proactive/file_monitor.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: File system monitoring for automated gap analysis in proactive research mode
 //! This module provides real-time file system monitoring capabilities for detecting
 //! changes that could indicate knowledge gaps in project documentation.

--- a/fortitude/src/proactive/gap_analyzer.rs
+++ b/fortitude/src/proactive/gap_analyzer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Gap detection algorithms for automated knowledge gap analysis in proactive research mode
 //! This module provides algorithms for detecting various types of knowledge gaps in codebases:
 //! - TODO/FIXME/HACK comments and their context

--- a/fortitude/src/proactive/impact_assessor.rs
+++ b/fortitude/src/proactive/impact_assessor.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Code usage pattern impact assessment for knowledge gap prioritization in proactive research mode
 //! This module provides sophisticated impact assessment that analyzes code usage patterns, dependency
 //! relationships, API visibility, and development activity to determine the potential impact of addressing

--- a/fortitude/src/proactive/integrated_analyzer.rs
+++ b/fortitude/src/proactive/integrated_analyzer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Integrated gap analyzer combining standard gap detection with semantic analysis
 //! This module provides an integrated analyzer that combines the gap detection from Task 1.2
 //! with the semantic analysis capabilities from Task 1.3, creating a complete pipeline

--- a/fortitude/src/proactive/manager.rs
+++ b/fortitude/src/proactive/manager.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Proactive research manager for CLI integration and component coordination
 //! This module provides a high-level manager for coordinating all proactive research components.
 //! It serves as the main interface between the CLI commands and the underlying proactive system,

--- a/fortitude/src/proactive/mod.rs
+++ b/fortitude/src/proactive/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Proactive research mode module for automated gap analysis and background research
 //! This module provides automated knowledge gap detection and background research execution.
 //! It monitors file system changes, analyzes documentation gaps, and executes research tasks

--- a/fortitude/src/proactive/notification_delivery_verifier.rs
+++ b/fortitude/src/proactive/notification_delivery_verifier.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Notification delivery verification system for comprehensive testing and validation
 //! This module provides real-time delivery verification, performance monitoring, and audit trails
 //! for the notification system. Features include:

--- a/fortitude/src/proactive/notification_system.rs
+++ b/fortitude/src/proactive/notification_system.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Multi-channel notification system for proactive research events and status updates
 //! This module provides a comprehensive notification system with multiple delivery channels
 //! for the proactive research system. Features include:

--- a/fortitude/src/proactive/notification_testing_harness.rs
+++ b/fortitude/src/proactive/notification_testing_harness.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Testing infrastructure and mock channels for comprehensive notification system testing
 //! This module provides comprehensive testing infrastructure for the notification system
 //! including mock channels, test harnesses, and stress testing capabilities. Features include:

--- a/fortitude/src/proactive/prioritization.rs
+++ b/fortitude/src/proactive/prioritization.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Intelligent prioritization algorithms for knowledge gap research urgency assessment
 //! This module provides sophisticated prioritization algorithms that intelligently rank research tasks
 //! based on multiple urgency factors. The system evaluates research urgency using:

--- a/fortitude/src/proactive/progress_tracker.rs
+++ b/fortitude/src/proactive/progress_tracker.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Enhanced progress tracking system for background research tasks with detailed step monitoring
 //! This module provides comprehensive progress tracking for research tasks with features including:
 //! - Real-time progress updates during task execution with detailed step tracking

--- a/fortitude/src/proactive/research_completion.rs
+++ b/fortitude/src/proactive/research_completion.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research completion notification system with comprehensive result summaries
 //! This module provides comprehensive research completion notifications with detailed
 //! result summaries for proactive research tasks. Features include:

--- a/fortitude/src/proactive/scheduler.rs
+++ b/fortitude/src/proactive/scheduler.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Research task scheduling system with configurable intervals for proactive research mode
 //! This module provides a comprehensive scheduling system that orchestrates the complete
 //! pipeline from gap analysis to research execution. Features include:

--- a/fortitude/src/proactive/semantic_analyzer.rs
+++ b/fortitude/src/proactive/semantic_analyzer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Semantic analysis integration for knowledge gap detection using vector database
 //! This module provides semantic analysis capabilities for the gap detection system.
 //! It integrates with the vector database to validate gaps, find related content,

--- a/fortitude/src/proactive/state_manager.rs
+++ b/fortitude/src/proactive/state_manager.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Centralized task state management system with comprehensive lifecycle tracking
 //! This module provides a centralized state management system for research tasks that enhances
 //! the existing state management with comprehensive lifecycle tracking, persistence, recovery,

--- a/fortitude/src/proactive/task_executor.rs
+++ b/fortitude/src/proactive/task_executor.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Background task executor with concurrency limits and rate limiting for research tasks
 //! This module provides a background task executor that processes research tasks from the queue
 //! with proper concurrency limits, rate limiting, and resource management. Features include:

--- a/fortitude/src/proactive/user_preferences.rs
+++ b/fortitude/src/proactive/user_preferences.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: User preference integration for priority customization in proactive research mode
 //! This module provides comprehensive user preference management that allows users to customize
 //! priority scoring weights, domain preferences, gap type priorities, workflow modes, and other

--- a/fortitude/src/providers/claude.rs
+++ b/fortitude/src/providers/claude.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Anthropic Claude provider implementation with Messages API v2, rate limiting, and error handling
 //! This module provides a concrete implementation of the Provider trait for Anthropic's Claude API.
 //! Features include Anthropic Messages API v2 integration, token bucket rate limiting, comprehensive

--- a/fortitude/src/providers/config.rs
+++ b/fortitude/src/providers/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Provider configuration structures with validation and environment support
 //! This module provides configuration structures for multi-LLM providers including
 //! API credentials, rate limiting, retry policies, and timeout settings.

--- a/fortitude/src/providers/fallback.rs
+++ b/fortitude/src/providers/fallback.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Fallback strategy implementation for multi-LLM provider system
 //! This module provides advanced fallback strategies for the Fortitude multi-LLM provider system.
 //! It implements intelligent provider selection, health monitoring, circuit breaker patterns,

--- a/fortitude/src/providers/gemini.rs
+++ b/fortitude/src/providers/gemini.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Google Gemini provider implementation with Google AI API, safety settings, and token counting
 //! This module provides a concrete implementation of the Provider trait for Google's Gemini API.
 //! Features include Google AI API v1beta integration, safety settings configuration, token counting,

--- a/fortitude/src/providers/manager.rs
+++ b/fortitude/src/providers/manager.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Provider manager for dynamic provider selection, fallback, and performance tracking
 //! This module provides the ProviderManager that orchestrates multiple LLM providers for research queries.
 //! It handles intelligent provider selection, automatic failover, performance tracking, and cost optimization.

--- a/fortitude/src/providers/mock.rs
+++ b/fortitude/src/providers/mock.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Mock provider implementation for testing
 //! Mock provider implementation that can be used for testing and development.
 //! Provides configurable responses, delays, and failure modes.

--- a/fortitude/src/providers/mod.rs
+++ b/fortitude/src/providers/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Multi-LLM provider abstraction trait and core definitions
 //! This module provides the core provider abstraction trait for multi-LLM support.
 //! It defines async interfaces for research queries, error handling, provider metadata,

--- a/fortitude/src/providers/openai.rs
+++ b/fortitude/src/providers/openai.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: OpenAI provider implementation with rate limiting, error handling, and token counting
 //! This module provides a concrete implementation of the Provider trait for OpenAI's API.
 //! Features include token bucket rate limiting, comprehensive error mapping, cost estimation,

--- a/fortitude/src/quality/config.rs
+++ b/fortitude/src/quality/config.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Centralized configuration management for all quality control systems
 //! This module provides comprehensive configuration management for the entire
 //! quality control ecosystem, including scoring, cross-validation, feedback,

--- a/fortitude/src/quality/cross_validation.rs
+++ b/fortitude/src/quality/cross_validation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Cross-provider validation system for research consistency across multiple LLM providers
 //! This module implements cross-provider validation to achieve >95% research accuracy through
 //! consistency checking, conflict resolution, and consensus generation across multiple LLM providers.

--- a/fortitude/src/quality/feedback.rs
+++ b/fortitude/src/quality/feedback.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: User feedback integration system for quality learning and continuous improvement
 //! This module implements a comprehensive user feedback integration system that learns from
 //! user interactions to continuously improve research quality through multiple feedback mechanisms,

--- a/fortitude/src/quality/metrics.rs
+++ b/fortitude/src/quality/metrics.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Automated quality metrics collection and storage system for comprehensive research quality monitoring
 //! This module provides automated collection, storage, and analysis of quality metrics
 //! to continuously monitor research quality and system performance. It supports real-time

--- a/fortitude/src/quality/mod.rs
+++ b/fortitude/src/quality/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Quality scoring framework for evaluating LLM research outputs
 //! This module provides comprehensive quality assessment algorithms to evaluate
 //! research outputs with multi-dimensional scoring across relevance, accuracy,

--- a/fortitude/src/quality/optimization.rs
+++ b/fortitude/src/quality/optimization.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Quality-based provider selection optimization system for >95% research accuracy
 //! This module implements an intelligent provider selection optimization system that uses
 //! comprehensive quality metrics, machine learning, and real-time adaptation to achieve

--- a/fortitude/src/quality/optimization_minimal.rs
+++ b/fortitude/src/quality/optimization_minimal.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Sprint 009 Task 2.5: Minimal Quality-based provider selection optimization
 //! This is a minimal working implementation of the quality optimization system
 //! that demonstrates the core concepts without requiring all complex dependencies.

--- a/fortitude/src/quality/provider_integration.rs
+++ b/fortitude/src/quality/provider_integration.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Provider integration for real-time quality evaluation
 //! This module provides integration between the quality scoring system and
 //! the multi-provider research engine, enabling real-time quality assessment

--- a/fortitude/src/quality/scoring.rs
+++ b/fortitude/src/quality/scoring.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Quality scoring algorithms for evaluating LLM research outputs
 //! This module implements comprehensive scoring algorithms for evaluating the quality
 //! of research outputs across multiple dimensions including relevance, accuracy,

--- a/fortitude/src/research.rs
+++ b/fortitude/src/research.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/fortitude/src/research_engine_adapter.rs
+++ b/fortitude/src/research_engine_adapter.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // ABOUTME: Adapter to integrate provider system with research engine
 //! This module provides adapters to integrate the multi-LLM provider system
 //! with the research engine trait implementations, enabling seamless provider

--- a/tools/fortitude-integration/src/main.rs
+++ b/tools/fortitude-integration/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use colored::*;

--- a/tools/quality-gates/src/main.rs
+++ b/tools/quality-gates/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 CE-DPS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::Parser;


### PR DESCRIPTION
This commit adds Apache 2.0 license copyright headers to all 211 Rust source files (.rs) throughout the project including:

- Main source files in tools/quality-gates and tools/fortitude-integration
- All Fortitude crate source files across multiple modules
- Test files, benchmark files, and example files

The copyright headers follow the standard Apache 2.0 format and include:
- Copyright 2025 CE-DPS Project attribution
- Apache 2.0 license reference with full URL
- Standard license disclaimer text

This completes the Apache 2.0 licensing implementation for the repository, ensuring all source files have proper copyright attribution and license information for legal compliance and distribution.

🤖 Generated with [Claude Code](https://claude.ai/code)